### PR TITLE
Change uniqueSessionPerVisit switch to showcasePrivacy radio buttons

### DIFF
--- a/croquet-metaverse-web-showcase.php
+++ b/croquet-metaverse-web-showcase.php
@@ -115,12 +115,16 @@ function croquet_metaverse_web_showcase_dynamic_render_callback( $block_attribut
 
   // do_action("qm/debug", '$src: ' . $src);
 
-  $uniqueSessionPerVisit = $block_attributes['uniqueSessionPerVisit'];
+  $showcasePrivacy = $block_attributes['showcasePrivacy'];
   
-  if ($uniqueSessionPerVisit) {
+  if ($showcasePrivacy == 'public') {
+    $sessionKey = '?q=' . $sanitizedName . '#pw=1';
+  } else if ($showcasePrivacy == 'invite') {
     $sessionKey = '';
   } else {
-    $sessionKey = '?q=' . $sanitizedName . '#pw=1';
+    // Default to `invite`.
+    // Perhaps we want to log something here, because we should never hit this codepath.
+    $sessionKey = '';
   }
 
   $result = wp_kses('<div class="showcase-container"><iframe width="100%" height=' . $minHeight . ' class="showcase-iframe" src="' . $src . $sessionKey . '"></iframe></div>',

--- a/readme.md
+++ b/readme.md
@@ -61,9 +61,10 @@ Visit [croquet.io/webshowcase](https://croquet.io/webshowcase) for more informat
 
 The key is used to access the Croquet Reflector network. You can generate an API Key, which is a string looks like 15kkttz5HqJ4mDycjupJA5eiF2CMhdvIgexample on https://croquet.io/keys.
 
-### Create a unique session per visit
+### Showcase Privacy
 
-When true, a visitor goes into a new Showcase session when they open the WordPress page. When false, they go into the same session. You can still share the session by clicking on the three bar menu within the Shwocase instance and scan the QR code or share the internal link.
+- When this setting is set to "Invite Only" (the default), **each visitor to your WordPress page will enter a new, unique Showcase session**. Visitors can invite others into their Showcase session using the QR code or the Invite link in the three-bar application menu.
+- When this setting is set to "Public", **every visitor to your WordPress page will enter the same session**. Visitors to your Showcase can invite other people via their URL in their browser's address bar. Visitors can also invite others into that Showcase session using the QR code or the Invite link in the three-bar application menu.
 
 ### Voice Chat
 

--- a/readme.txt
+++ b/readme.txt
@@ -60,10 +60,10 @@ This API key is used to access the Croquet Reflector network. You can generate a
 
 These API keys are public and **not secret**. Usage of the API key can be restricted to a set of URLs.
 
-= Create a unique session per visit =
+= Showcase Privacy =
 
-When this switch is enabled, a visitor to your WordPress page will enter a new, unique Showcase session. Visitors can invite others into their Showcase session using the QR code or the Invite link in the three-bar application menu.
-When this switch is disabled, every visitor to your WordPress page will enter the same session. Visitors can invite others into that Showcase session using the QR code or the Invite link in the three-bar application menu.
+When this setting is set to "Invite Only" (the default), **each visitor to your WordPress page will enter a new, unique Showcase session**. Visitors can invite others into their Showcase session using the QR code or the Invite link in the three-bar application menu.
+When this setting is set to "Public", **every visitor to your WordPress page will enter the same session**. Visitors to your Showcase can invite other people via their URL in their browser's address bar. Visitors can also invite others into that Showcase session using the QR code or the Invite link in the three-bar application menu.
 
 = Voice Chat =
 

--- a/src/block.json
+++ b/src/block.json
@@ -33,10 +33,10 @@
             "selector": "div",
             "default": true
         },
-        "uniqueSessionPerVisit": {
-            "type": "boolean",
+        "showcasePrivacy": {
+            "type": "string",
             "selector": "div",
-            "default": true
+            "default": "invite"
         }
     },
     "supports": {

--- a/src/edit.js
+++ b/src/edit.js
@@ -271,9 +271,7 @@ export default function Edit({ attributes, setAttributes }) {
 
     let apiKeyHelp = __("A key to access the Croquet network. You can generate one on https://croquet.io/keys. Paste the key string that looks like: 1abcdefg123456890ABCDEFG", "croquet-metaverse-web-showcase");
 
-    let showcasePrivacyHelp = (flag) => {
-        return __("Determines the privacy of this Web Showcase instantiation", "croquet-metaverse-web-showcase");
-    };
+    let showcasePrivacyHelp = __("Determines the privacy of this Web Showcase instantiation", "croquet-metaverse-web-showcase");
 
     let dolbyAudioHelp = (flag) => {
         if (flag) {

--- a/src/edit.js
+++ b/src/edit.js
@@ -11,6 +11,7 @@ import {
     TextControl,
     // ComboboxControl,
     ToggleControl,
+    RadioControl,
     __experimentalVStack as VStack,
     __experimentalUnitControl as UnitControl,
     __experimentalDivider as Divider,
@@ -56,7 +57,7 @@ export default function Edit({ attributes, setAttributes }) {
     let [apiKey, setApiKey] = useState(attributes.apiKey);
     let [apiKeyCorrect, setApiKeyCorrect] = useState(true);
     let [showcaseName, setShowcaseName] = useState(attributes.showcaseName);
-    let [uniqueSessionPerVisit, setUniqueSessionPerVisit] = useState(attributes.uniqueSessionPerVisit);
+    let [showcasePrivacy, setShowcasePrivacy] = useState(attributes.showcasePrivacy);
     let [voiceChat, setVoiceChat] = useState(attributes.voiceChat);
     let [showingNotice, setShowingNotice] = useState(false);
 
@@ -170,9 +171,9 @@ export default function Edit({ attributes, setAttributes }) {
         setMinHeight(val);
     };
 
-    let updateUniqueSessionPerVisit = (val) => {
-        setAttributes({uniqueSessionPerVisit: val});
-        setUniqueSessionPerVisit(val);
+    let updateShowcasePrivacy = (val) => {
+        setAttributes({showcasePrivacy: val});
+        setShowcasePrivacy(val);
     };
 
     let updateVoiceChat = (val) => {
@@ -270,11 +271,8 @@ export default function Edit({ attributes, setAttributes }) {
 
     let apiKeyHelp = __("A key to access the Croquet network. You can generate one on https://croquet.io/keys. Paste the key string that looks like: 1abcdefg123456890ABCDEFG", "croquet-metaverse-web-showcase");
 
-    let uniqueSessionHelp = (flag) => {
-        if (flag) {
-            return __("Every new visitor goes into a new session", "croquet-metaverse-web-showcase");
-        }
-        return __("All visitors go into the same session", "croquet-metaverse-web-showcase");
+    let showcasePrivacyHelp = (flag) => {
+        return __("Determines the privacy of this Web Showcase instantiation", "croquet-metaverse-web-showcase");
     };
 
     let dolbyAudioHelp = (flag) => {
@@ -301,11 +299,16 @@ export default function Edit({ attributes, setAttributes }) {
                         value={apiKey}
                         help={apiKeyHelp}
                         onChange={updateApiKey}/>
-                    <ToggleControl
-                        label={__("Create a unique session per visit", "croquet-metaverse-web-showcase")}
-                        checked={uniqueSessionPerVisit}
-                        help={uniqueSessionHelp}
-                        onChange={updateUniqueSessionPerVisit}/>
+                    <RadioControl
+                        label={__("Showcase Privacy", "croquet-metaverse-web-showcase")}
+                        help={showcasePrivacyHelp}
+                        selected={showcasePrivacy}
+                        options={[
+                            { label: 'Invite Only', value: 'invite' },
+                            { label: 'Public', value: 'public' },
+                        ]}
+                        onChange={updateShowcasePrivacy}
+                    />
                     <ToggleControl
                         label={__("Enable Dolby spatial voice chat", "croquet-metaverse-web-showcase")}
                         checked={voiceChat}


### PR DESCRIPTION
I made this change to maintain parity with incoming changes to Showcase for the Web.

- I didn't test these changes; I don't know the best ways to do that. :)
- I don't know how to regenerate the `.pot` i18n file. That'll need to be done before committing these changes.